### PR TITLE
Update shard so that it is more stable for production apps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    target-branch: main

--- a/.github/workflows/shard.yml
+++ b/.github/workflows/shard.yml
@@ -1,0 +1,26 @@
+name: Shard CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  LintAndTest:
+    strategy:
+      matrix:
+        container:
+          - crystallang/crystal:latest-alpine
+          - crystallang/crystal:nightly-alpine
+
+    runs-on: ubuntu-latest
+
+    container: ${{ matrix.container }}
+
+    steps:
+      - name: Check format
+        run: crystal tool format --check
+
+      - name: Run tests
+        run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # carbon_aws_ses_adapter
 
-[![Build Status](https://travis-ci.org/keizo3/carbon_aws_ses_adapter.svg?branch=master)](https://travis-ci.org/keizo3/carbon_aws_ses_adapter)
+![Build Status](https://github.com/keizo3/carbon_aws_ses_adapter/workflows/Shard%20CI/badge.svg)
 
 This is luckyframework/carbon's adapter for AWS SES
 
@@ -16,6 +16,12 @@ dependencies:
     github: keizo3/carbon_aws_ses_adapter
 ```
 
+Add this to your application's `shards.cr`:
+
+```crystal
+require "carbon_aws_ses_adapter"
+```
+
 ## Usage
 
 ### Configure the mailer class
@@ -24,6 +30,7 @@ dependencies:
 2. create iam user for send AWS SES on your AWS Console
 3. get iam user credentials
 4. setting adapter
+
 ```crystal
 require "carbon_aws_ses_adapter"
 
@@ -34,10 +41,10 @@ end
 
 ## Development
 
-* `shards install`
-* Make changes
-* `crystal spec` (will skip sending test emails to AWS SES)
-* `crystal spec -D send_real_email` requires a `AWS_SES_KEY` `AWS_SES_SECRET` `AWS_SES_REGION` ENV variable. Set this in a .env file:
+- `shards install`
+- Make changes
+- `crystal spec` (will skip sending test emails to AWS SES)
+- `crystal spec -D send_real_email` requires a `AWS_SES_KEY` `AWS_SES_SECRET` `AWS_SES_REGION` ENV variable. Set this in a .env file:
 
 ```
 # in .env

--- a/shard.yml
+++ b/shard.yml
@@ -1,17 +1,18 @@
 name: carbon_aws_ses_adapter
-version: 1.0.0
+version: 1.1.0
 
 authors:
   - keizo3 <keizo.suzuki3@gmail.com>
 
-crystal: 0.27.2
+crystal: 0.35.1
 
 dependencies:
   habitat:
     github: luckyframework/habitat
+    version: ~> 0.4.4
   carbon:
     github: luckyframework/carbon
-    branch: master
+    version: ~> 0.1.2
 
 development_dependencies:
   dotenv:


### PR DESCRIPTION
Thank you for the wonderful work on this adapter for Carbon!

I added a few items to this PR:

- Currently, you're not able to use this shard against the default Lucky app due to the Carbon dependency being locked to the `master` branch. I bumped that to the latest version, and the tests seem to pass!
- I locked the Habitat shard to a specific version as well to protect downstream apps from breaking changes
- I moved the Travis CI to GitHub actions so that we can do matrix testing against both the latest and nightly Crystal version
- I bumped the Crystal version in `shard.yml` to 0.35.1
- I added some additional detail for how to require the shard in a Lucky app under the Installation section of the README
- I added a Dependabot configuration so that the GitHub actions stay up-to-date