### PR TITLE
Resolve OpenSSL::Digest deprecation and refactor tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /lib/
 /.shards/
 /shard.lock
+.env

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# carbon_aws_ses_adapter
+# Carbon AWS SES Adapter
 
 ![Build Status](https://github.com/keizo3/carbon_aws_ses_adapter/workflows/Shard%20CI/badge.svg)
 
-This is luckyframework/carbon's adapter for AWS SES
+This is luckyframework/carbon's adapter for [AWS SES (Simple Email Service)](https://aws.amazon.com/ses/)
 
 https://github.com/luckyframework/carbon
 
@@ -24,18 +24,27 @@ require "carbon_aws_ses_adapter"
 
 ## Usage
 
+### Configure AWS SES Simple Email Service
+
+1. Go to the [Amazon Web Services developer console](https://console.aws.amazon.com/).
+1. Ensure that AWS SES is correctly set up according to [the documentation](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/send-email-set-up.html).
+1. Create an AWS IAM user who can send emails. The user must have at least the following permissions:
+   - `ses:SendEmail`
+   - `ses:SendRawEmail`
+1. Copy the AWS Access Key and AWS Secret Access key for the IAM user you've created.
+1. Set up the adapter in Lucky via the `config/email.cr` file.
+
 ### Configure the mailer class
 
-1. setting AWS SES on your AWS Console
-2. create iam user for send AWS SES on your AWS Console
-3. get iam user credentials
-4. setting adapter
-
 ```crystal
-require "carbon_aws_ses_adapter"
+# config/email.cr
 
 BaseEmail.configure do
-  settings.adapter = Carbon::AwsSesAdapter.new(key: ENV["AWS_SES_KEY"], secret: ENV["AWS_SES_SECRET"], region: ENV["AWS_SES_REGION"])
+  settings.adapter = Carbon::AwsSesAdapter.new(
+    key:    ENV["AWS_SES_ACCESS_KEY"],
+    secret: ENV["AWS_SES_SECRET_KEY_KEY"],
+    region: ENV["AWS_SES_REGION"]
+  )
 end
 ```
 
@@ -44,15 +53,16 @@ end
 - `shards install`
 - Make changes
 - `crystal spec` (will skip sending test emails to AWS SES)
-- `crystal spec -D send_real_email` requires a `AWS_SES_KEY` `AWS_SES_SECRET` `AWS_SES_REGION` ENV variable. Set this in a .env file:
+- `crystal spec -D send_real_email` (will send real emails, and requires the below `.env` file content)
 
 ```
-# in .env
+# In .env
 # If you want to run tests that actually test emails against the AWS SES
-AWS_SES_KEY=get_from_aws_ses_key
-AWS_SES_SECRET=get_from_aws_ses_secret
+AWS_SES_ACCESS_KEY=get_from_aws_ses_key
+AWS_SES_SECRET_KEY=get_from_aws_ses_secret
 AWS_SES_REGION=get_from_aws_ses_region
 AWS_SES_FROM_ADDRESS=verified_address
+AWS_SES_TO_ADDRESS=recipient_address
 ```
 
 ## Contributing

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: carbon_aws_ses_adapter
-version: 1.1.0
+version: 1.2.0
 
 authors:
   - keizo3 <keizo.suzuki3@gmail.com>

--- a/spec/adapters/aws_ses_adapter_spec.cr
+++ b/spec/adapters/aws_ses_adapter_spec.cr
@@ -4,14 +4,12 @@ describe "AwsSES adapter" do
   {% if flag?("send_real_email") %}
     describe "deliver_now" do
       it "delivers the email successfully" do
-        send_email_to_aws_ses text_body: "text template",
-          to: [Carbon::Address.new("keizo.suzuki3@gmail.com")]
+        send_email_to_aws_ses text_body: "This is a test sent from https://keizo3/carbon_aws_ses_adapter."
       end
 
       it "delivers emails with reply_to set" do
-        send_email_to_aws_ses text_body: "text template",
-          to: [Carbon::Address.new("keizo.suzuki3@gmail.com")],
-          headers: {"Reply-To" => "keizo.suzuki3@gmail.com"}
+        send_email_to_aws_ses text_body: "This is a test sent from https://keizo3/carbon_aws_ses_adapter.",
+          headers: {"Reply-To" => ENV.fetch("AWS_SES_TO_ADDRESS")}
       end
     end
   {% end %}
@@ -29,7 +27,7 @@ describe "AwsSES adapter" do
     end
 
     it "create authorization" do
-      params_for()[:authorization].should eq "AWS4-HMAC-SHA256 Credential=fake_key/20190102/fake_region/ses/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=64e1f5faffaafd5647b690bd7aa8bfc1bfc40f743d911344db4786d548eb6cc3"
+      params_for()[:authorization].should eq "AWS4-HMAC-SHA256 Credential=fake_key/20190102/fake_region/ses/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=7f0bbf212f6f9e232dde0e0917be4d296a328459e051f9032e725d9c13af8264"
     end
 
     it "create k_signing" do
@@ -37,11 +35,11 @@ describe "AwsSES adapter" do
     end
 
     it "create m_signing" do
-      params_for()[:m_signing].should eq "AWS4-HMAC-SHA256\n20190102T154556Z\n20190102/fake_region/ses/aws4_request\nd3cc80138c455e26a60d7bef8dbd29a2afdda481fe289d567a529ab1168c059e"
+      params_for()[:m_signing].should eq "AWS4-HMAC-SHA256\n20190102T154556Z\n20190102/fake_region/ses/aws4_request\ne0c5ef7baf80c18a6805b9f9d4a66c17fcb8de436686d61d5e328f499dae080a"
     end
 
     it "create canonical_string" do
-      params_for()[:canonical_string].should eq "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf-8\nhost:email.fake_region.amazonaws.com\nx-amz-date:20190102T154556Z\n\ncontent-type;host;x-amz-date\nba4b738819697b17efbd1154e1e758dac63d99af848615d146296e066214e806"
+      params_for()[:canonical_string].should eq "POST\n/\n\ncontent-type:application/x-www-form-urlencoded; charset=utf-8\nhost:email.fake_region.amazonaws.com\nx-amz-date:20190102T154556Z\n\ncontent-type;host;x-amz-date\n898544300f10156174ad93313e7259be9e8f17e5dd21a60cfa845fa56d8479a9"
     end
 
     it "hash256" do
@@ -65,7 +63,7 @@ describe "AwsSES adapter" do
     end
 
     it "handles send_mail_params" do
-      params_for()[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=subject"
+      params_for()[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=%5BCarbonAwsSesAdapter%5D%20Test%20Email"
     end
 
     it "handles send_mail_params multi addresses with name" do
@@ -84,7 +82,7 @@ describe "AwsSES adapter" do
         bcc: [bcc_without_name, bcc_with_name]
       )
 
-      multiaddress_params[:send_mail_params].should eq "Action=SendEmail&Source=Sally%20%3Cfrom%40example.com%3E&Destination.ToAddresses.member.1=%3Cto%40example.com%3E&Destination.ToAddresses.member.2=Jimmy%20%3Cto2%40example.com%3E&Destination.CcAddresses.member.1=%3Ccc%40example.com%3E&Destination.CcAddresses.member.2=Kim%20%3Ccc2%40example.com%3E&Destination.BccAddresses.member.1=%3Cbcc%40example.com%3E&Destination.BccAddresses.member.2=James%20%3Cbcc2%40example.com%3E&Message.Subject.Data=subject"
+      multiaddress_params[:send_mail_params].should eq "Action=SendEmail&Source=Sally%20%3Cfrom%40example.com%3E&Destination.ToAddresses.member.1=%3Cto%40example.com%3E&Destination.ToAddresses.member.2=Jimmy%20%3Cto2%40example.com%3E&Destination.CcAddresses.member.1=%3Ccc%40example.com%3E&Destination.CcAddresses.member.2=Kim%20%3Ccc2%40example.com%3E&Destination.BccAddresses.member.1=%3Cbcc%40example.com%3E&Destination.BccAddresses.member.2=James%20%3Cbcc2%40example.com%3E&Message.Subject.Data=%5BCarbonAwsSesAdapter%5D%20Test%20Email"
     end
 
     it "sets the subject" do
@@ -92,9 +90,9 @@ describe "AwsSES adapter" do
     end
 
     it "sets the message body" do
-      params_for(text_body: "text")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=subject&Message.Body.Text.Data=text"
-      params_for(html_body: "html")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=subject&Message.Body.Html.Data=html"
-      params_for(text_body: "text", html_body: "html")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=subject&Message.Body.Text.Data=text&Message.Body.Html.Data=html"
+      params_for(text_body: "text")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=%5BCarbonAwsSesAdapter%5D%20Test%20Email&Message.Body.Text.Data=text"
+      params_for(html_body: "html")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=%5BCarbonAwsSesAdapter%5D%20Test%20Email&Message.Body.Html.Data=html"
+      params_for(text_body: "text", html_body: "html")[:send_mail_params].should eq "Action=SendEmail&Source=%3Cfrom%40example.com%3E&Message.Subject.Data=%5BCarbonAwsSesAdapter%5D%20Test%20Email&Message.Body.Text.Data=text&Message.Body.Html.Data=html"
     end
   end
 end
@@ -112,12 +110,13 @@ private def params_for(**email_attrs)
 end
 
 private def send_email_to_aws_ses(**email_attrs)
-  key = ENV.fetch("AWS_SES_KEY")
-  secret = ENV.fetch("AWS_SES_SECRET")
+  key = ENV.fetch("AWS_SES_ACCESS_KEY")
+  secret = ENV.fetch("AWS_SES_SECRET_KEY")
   region = ENV.fetch("AWS_SES_REGION")
-  from_address = ENV["AWS_SES_FROM_ADDRESS"]? || "from@example.com"
+  from_address = ENV.fetch("AWS_SES_FROM_ADDRESS", "from@example.com")
+  to_address = ENV.fetch("AWS_SES_TO_ADDRESS")
 
-  email = FakeEmail.new(**email_attrs, from: Carbon::Address.new(from_address))
+  email = FakeEmail.new(**email_attrs, to: [Carbon::Address.new(to_address)], from: Carbon::Address.new(from_address))
   adapter = Carbon::AwsSesAdapter.new(key: key, secret: secret, region: region, sandbox: true)
 
   adapter.deliver_now(email)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,8 @@
 require "spec"
 require "carbon"
+require "dotenv"
+
 require "./support/**"
 require "../src/adapters/aws_ses_adapter.cr"
+
+Dotenv.load

--- a/spec/support/fake_email.cr
+++ b/spec/support/fake_email.cr
@@ -7,7 +7,7 @@ class FakeEmail < Carbon::Email
     @cc = [] of Carbon::Address,
     @bcc = [] of Carbon::Address,
     @headers = {} of String => String,
-    @subject = "subject",
+    @subject = "[CarbonAwsSesAdapter] Test Email",
     @text_body : String? = nil,
     @html_body : String? = nil
   )

--- a/src/adapters/aws_ses_adapter.cr
+++ b/src/adapters/aws_ses_adapter.cr
@@ -135,10 +135,10 @@ class Carbon::AwsSesAdapter < Carbon::Adapter
       canonical_string += "#{hash256(send_mail_params)}"
     end
 
-    private def hash256(data)
+    private def hash256(data : String) : String
       hash = OpenSSL::Digest.new("SHA256")
       hash.update(data)
-      hash.hexdigest
+      hash.final.hexstring
     end
 
     @_client : HTTP::Client?


### PR DESCRIPTION
This PR adds a few quality-of-life improvements for development, and one deprecation fix:

- Resolved deprecation warning from using `OpenSSL::Digest.new("SHA256").hexdigest` to use `final.hexstring` instead, as recommended in deprecation warnings
- Updated README with more detail and links to Amazon SES guides, where applicable
- Refactored test suite not to have a hard-coded `to` email address, and to pull it from the environment instead
- Updated test email subject and body to be more informative about which library they're being sent from
- Updated hard-coded test verification values to match the new test email subject line (**please verify this, I wasn't 100% sure if I should touch those strings or not**)
- Loaded the `Dotenv` library in `spec_helper.cr` so that `.env` files can be read
- Added `.env` to `.gitignore` so that local development is easier

I suggested a version bump to **v1.2.0**, but please let me know if you don't want me to suggest those bumps in PRs themselves!