### PR TITLE
Bump shard to support Crystal 1.0

### DIFF
--- a/.github/workflows/shard.yml
+++ b/.github/workflows/shard.yml
@@ -10,13 +10,15 @@ jobs:
   LintAndTest:
     strategy:
       matrix:
-        container:
-          - crystallang/crystal:latest-alpine
-          - crystallang/crystal:nightly-alpine
+        crystal_version:
+          - 0.35.1
+          - 0.36.1
+          - latest
+          - nightly
 
     runs-on: ubuntu-latest
 
-    container: ${{ matrix.container }}
+    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
 
     steps:
       - name: Check format

--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ version: 1.3.0
 authors:
   - keizo3 <keizo.suzuki3@gmail.com>
 
-crystal: ">= 0.35.0, < 2.0.0"
+crystal: ">= 0.35.1, < 2.0.0"
 
 dependencies:
   habitat:

--- a/shard.yml
+++ b/shard.yml
@@ -1,18 +1,19 @@
 name: carbon_aws_ses_adapter
-version: 1.2.0
+description: An email adapter for Amazon SES that integrates with Carbon
+version: 1.3.0
 
 authors:
   - keizo3 <keizo.suzuki3@gmail.com>
 
-crystal: 0.35.1
+crystal: ">= 0.35.0, < 2.0.0"
 
 dependencies:
   habitat:
     github: luckyframework/habitat
-    version: ~> 0.4.4
+    version: ~> 0.4.7
   carbon:
     github: luckyframework/carbon
-    version: ~> 0.1.2
+    version: ~> 0.1.4
 
 development_dependencies:
   dotenv:


### PR DESCRIPTION
I also took the liberty of updating the GitHub actions to test against all supported versions (plus nightly), and bumped the `shard.yml` version so that all that's left to do is tag a release.